### PR TITLE
fix: broken compose build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ RUN sed -i '/deb http:\/\/deb.debian.org\/debian stretch-updates main/d' /etc/ap
   && apt-get remove -y libpng-dev libjpeg-dev libfreetype6-dev \
   && rm -fr /var/cache/apt/*
 
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
 COPY . /var/www/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:5.6-apache-stretch
+FROM php:8.1-apache-bullseye
 
 RUN sed -i '/deb http:\/\/deb.debian.org\/debian stretch-updates main/d' /etc/apt/sources.list \
   && apt-get -o Acquire::Check-Valid-Until=false update \
   && apt-get install -y libpng16-16 libjpeg62-turbo libpng-dev libjpeg-dev libfreetype6 libfreetype6-dev \
-  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+  && docker-php-ext-configure gd --with-freetype --with-jpeg \
   && docker-php-ext-install mysqli gd \
   && apt-get remove -y libpng-dev libjpeg-dev libfreetype6-dev \
   && rm -fr /var/cache/apt/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    image: mariadb:10.3
+    image: mariadb:10.9
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=multifaucet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - .env
     volumes:
       - ./config/faucet:/var/www/html/config:ro
-      - ./config/php:/usr/local/etc/php:ro
+      - ./config/php/php.ini:/usr/local/etc/php/conf.d/php.ini:ro
     ports:
       - 80:80
 


### PR DESCRIPTION
I think the fix we needed was to mount `php.ini` as a file, mounting the entire directory was destroying some other configuration needed, in the `/usr/local/etc/php/conf.d/mysqli.ini` file, which was being blocked by mounting the entire `config/php` directory.

I also updated the base image versions. I'm still having trouble with the network, but this might work better for you?